### PR TITLE
Fixed Upload Bug

### DIFF
--- a/client.py
+++ b/client.py
@@ -79,7 +79,10 @@ def download(client_socket, file_name, cwd):
 
 def upload(client_socket, path, cwd):
     # Get name of file from path
-    filename = path.split("/")[-1]
+    if os.name == 'nt':
+        filename = path.split("\\")[-1]
+    else:
+        filename = path.split("/")[-1]
     # Check if the file exists
     if not os.path.isfile(path):
         display_response(f"File '{filename}' does not exist.", "error")


### PR DESCRIPTION
On windows, when giving the absolute path of a file you want to upload on your system, the filename would become the entire path given as it only considered *nix paths before ("/" vs "\"). If the client is on windows it will split the path by "\".